### PR TITLE
Remove automerge syncing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2225,17 +2225,6 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
-    "automerge": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/automerge/-/automerge-0.14.0.tgz",
-      "integrity": "sha512-H0Lszio1ZywPpJ3bS8IZ8qGkmFYN/cLPXT30AD1gDz7LMd6NEhdbOA+uBLr97a4M4f3Xx0KtOAJrQ7Xjo4OCOQ==",
-      "requires": {
-        "immutable": "^3.8.2",
-        "transit-immutable-js": "^0.7.0",
-        "transit-js": "^0.8.861",
-        "uuid": "^3.4.0"
-      }
-    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -6117,11 +6106,6 @@
       "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
       "dev": true
     },
-    "immutable": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
-      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
-    },
     "import-lazy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
@@ -9859,6 +9843,12 @@
             "psl": "^1.1.28",
             "punycode": "^2.1.1"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -10563,6 +10553,14 @@
       "requires": {
         "faye-websocket": "^0.10.0",
         "uuid": "^3.0.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "sockjs-client": {
@@ -11244,16 +11242,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "transit-immutable-js": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/transit-immutable-js/-/transit-immutable-js-0.7.0.tgz",
-      "integrity": "sha1-mT4lCJtjEf9AIUD1VidtbSUwBdk="
-    },
-    "transit-js": {
-      "version": "0.8.861",
-      "resolved": "https://registry.npmjs.org/transit-js/-/transit-js-0.8.861.tgz",
-      "integrity": "sha512-4O9OrYPZw6C0M5gMTvaeOp+xYz6EF79JsyxIvqXHlt+pisSrioJWFOE80N8aCPoJLcNaXF442RZrVtdmd4wkDQ=="
-    },
     "tslib": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
@@ -11624,11 +11612,6 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
-    },
-    "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "v8-compile-cache": {
       "version": "2.0.3",
@@ -12352,6 +12335,14 @@
       "requires": {
         "ansi-colors": "^3.0.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "webpack-node-externals": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Spaceship Laboratory",
   "private": true,
   "dependencies": {
-    "automerge": "^0.14.0",
     "ws": "^7.2.3"
   },
   "devDependencies": {

--- a/src/client/crystal.js
+++ b/src/client/crystal.js
@@ -8,7 +8,6 @@ export class Crystal extends Moving {
   constructor({ offsetX, offsetY }) {
     let node = Stage.anim('crystal')
     super(node, offsetX, offsetY)
-    this.sync = new Event()
   }
 
   static add(stage, data, when) {
@@ -18,14 +17,6 @@ export class Crystal extends Moving {
     crystal.tick(age, stage)
     sounds.crystalSpawn.emit()
     return crystal
-  }
-
-  save(stage, data) {
-    // Nothing to save
-  }
-
-  load(stage, data, when) {
-    // Nothing to load
   }
 
   start(stage) {

--- a/src/client/node.js
+++ b/src/client/node.js
@@ -13,6 +13,7 @@ export class Node {
     this.rotation = rotation
     this.scale = scale
     this.remove = new Event()
+    this.sync = new Event()
   }
 
   append(stage) {
@@ -106,5 +107,19 @@ export class Node {
   scaleTo(newScale) {
     this.scale = newScale
     this.node.pin('scale', newScale)
+  }
+
+  /**
+   * Save updated state from the node.
+   */
+  save(stage, prev) {
+    return {} // Nothing to save
+  }
+
+  /**
+   * Load updated state from a prior save() call.
+   */
+  load(stage, saved, when) {
+    // Nothing to load
   }
 }

--- a/src/client/rock.js
+++ b/src/client/rock.js
@@ -11,7 +11,6 @@ export class Rock extends Moving {
     super(node, offsetX, offsetY, rotation, scale, velocityX, velocityY, spin)
     this.side = side
     this.shoot = new Event()
-    this.sync = new Event()
   }
 
   static add(stage, data, when) {
@@ -22,14 +21,24 @@ export class Rock extends Moving {
     return rock
   }
 
-  save(stage, data) {
-    data.velocityX = this.velocityX
-    data.velocityY = this.velocityY
+  save(stage, prev) {
+    let saved = super.save(stage, prev)
+    // Save the position and velocity, in case the rock was ricocheted
+    saved.offsetX = this.offsetX
+    saved.offsetY = this.offsetY
+    saved.velocityX = this.velocityX
+    saved.velocityY = this.velocityY
+    return saved
   }
 
   load(stage, data, when) {
+    super.load(stage, data, when)
+    // Load the position and velocity from the saved data
+    let age = when - data.mod
+    this.moveTo(data.offsetX, data.offsetY)
     this.velocityX = data.velocityX
     this.velocityY = data.velocityY
+    rock.tick(age, stage)
   }
 
   start(stage) {

--- a/src/conn.js
+++ b/src/conn.js
@@ -5,13 +5,9 @@ import { elapsed } from './time.js'
  * A single message sent from client to server or server to client.
  */
 export class Message {
-  constructor({ when = elapsed(), changes }) {
+  constructor({ when = elapsed(), changes = [] }) {
     this.when = when
     this.changes = changes
-  }
-
-  static fromJSON(str) {
-    return new Message(JSON.parse(str))
   }
 }
 

--- a/src/server/game.js
+++ b/src/server/game.js
@@ -25,9 +25,6 @@ export class Game {
   }
 
   start() {
-    // Initialize the shared state doc
-    this.doc.initialize()
-
     // Keep track of game connections
     const connections = new Set()
     let endTimeout = null

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,7 +1,7 @@
 import { strict as assert } from 'assert'
 import WebSocket from 'ws'
 import { Game } from './game.js'
-import { Connection } from '../conn.js'
+import { Message, Connection } from '../conn.js'
 
 const port = process.env.PORT || 8081
 const wss = new WebSocket.Server({ port })
@@ -31,8 +31,8 @@ wss.on('connection', (ws, req) => {
 
   // Use the websocket to synchronize the state docs
   const conn = new Connection()
-  conn.send.on(data => ws.send(JSON.stringify(data)))
-  ws.on('message', data => conn.recv.emit(JSON.parse(data)))
+  conn.send.on(data => ws.send(JSON.stringify(new Message(data))))
+  ws.on('message', data => conn.recv.emit(new Message(JSON.parse(data))))
   ws.on('close', () => conn.close.emit())
   game.join.emit(conn)
   conn.close.trigger(game.leave, conn)


### PR DESCRIPTION
Automerge was slow. This change gets rid of it.

Instead of pushing automerge changes on the websocket, it just uses regular JSON messages with updated data. Much faster!